### PR TITLE
Check for validator fields in $_POST

### DIFF
--- a/public/class-woocommerce-account.php
+++ b/public/class-woocommerce-account.php
@@ -23,9 +23,9 @@ Class WC_PV_Account{
         global $wc_pv_woo_custom_field_meta;
         $phone_name = $wc_pv_woo_custom_field_meta['billing_hidden_phone_field'];
         $phone_err_name = $wc_pv_woo_custom_field_meta['billing_hidden_phone_err_field'];
-        $phone_valid_field = strtolower( sanitize_text_field($_POST[$phone_name]) );
-        $phone_valid_err_field = trim( sanitize_text_field( $_POST[$phone_err_name] ) );
-		$bil_email = sanitize_email($_POST['billing_email']);
+        $phone_valid_field = isset( $_POST[$phone_name] ) ? strtolower( sanitize_text_field($_POST[$phone_name]) ) : '';
+        $phone_valid_err_field = isset( $_POST[$phone_err_name] ) ? trim( sanitize_text_field( $_POST[$phone_err_name] ) ) : '';
+	$bil_email = sanitize_email($_POST['billing_email']);
         $bil_phone = sanitize_text_field($_POST['billing_phone']);
 
         if( !empty($bil_email) && !empty($bil_phone) && (empty($phone_valid_field) || !is_numeric($phone_valid_field) ) ){//there was an error, this way we know its coming directly from normal woocommerce, so no conflict :)

--- a/public/class-woocommerce-account.php
+++ b/public/class-woocommerce-account.php
@@ -25,8 +25,8 @@ Class WC_PV_Account{
         $phone_err_name = $wc_pv_woo_custom_field_meta['billing_hidden_phone_err_field'];
         $phone_valid_field = isset( $_POST[$phone_name] ) ? strtolower( sanitize_text_field($_POST[$phone_name]) ) : '';
         $phone_valid_err_field = isset( $_POST[$phone_err_name] ) ? trim( sanitize_text_field( $_POST[$phone_err_name] ) ) : '';
-	$bil_email = sanitize_email($_POST['billing_email']);
-        $bil_phone = sanitize_text_field($_POST['billing_phone']);
+        $bil_email = isset( $_POST['billing_email'] ) ? sanitize_email($_POST['billing_email']) : '';
+        $bil_phone = isset( $_POST['billing_phone'] ) ? sanitize_text_field($_POST['billing_phone']) : '';
 
         if( !empty($bil_email) && !empty($bil_phone) && (empty($phone_valid_field) || !is_numeric($phone_valid_field) ) ){//there was an error, this way we know its coming directly from normal woocommerce, so no conflict :)
          $ph = explode(':',$phone_valid_err_field);

--- a/public/class-woocommerce-checkout.php
+++ b/public/class-woocommerce-checkout.php
@@ -78,8 +78,8 @@ Class WC_PV_Checkout{
         global $wc_pv_woo_custom_field_meta;
         $phone_name = $wc_pv_woo_custom_field_meta['billing_hidden_phone_field'];
         $phone_err_name = $wc_pv_woo_custom_field_meta['billing_hidden_phone_err_field'];
-        $phone_valid_field = strtolower( sanitize_text_field($_POST[$phone_name]) );
-        $phone_valid_err_field = trim( sanitize_text_field( $_POST[$phone_err_name] ) );
+        $phone_valid_field = isset( $_POST[$phone_name] ) ? strtolower( sanitize_text_field($_POST[$phone_name]) ) : '';
+        $phone_valid_err_field = isset( $_POST[$phone_err_name] ) ? trim( sanitize_text_field( $_POST[$phone_err_name] ) ) : '';
         $bil_email = sanitize_email($_POST['billing_email']);
         $bil_phone = sanitize_text_field($_POST['billing_phone']);
 		       


### PR DESCRIPTION
These minor changes avoid php throwing warnings if one or the other validator fields are not present in the $_POST.