### PR TITLE
Fix Undefined index: SERVER_NAME when in CLI context

### DIFF
--- a/wc-pv.php
+++ b/wc-pv.php
@@ -30,7 +30,7 @@ define('WC_PV_PLUGIN_VERSION','1.2.0');
  */
 $_wc_pv_env = 'production';
 
-if ( strpos( $_SERVER['SERVER_NAME'], 'localhost' ) !== false || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) )
+if ( isset( $_SERVER['SERVER_NAME'] ) && strpos( $_SERVER['SERVER_NAME'], 'localhost' ) !== false || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) )
     $_wc_pv_env = 'test';
 
 define( 'WC_PV_ENVIRONMENT', $_wc_pv_env );


### PR DESCRIPTION
you get a PHP notice when doing things in CLI because I assume the `$_SERVER` global isn't set at all.