### PR TITLE
Reinitialize on updated_checkout

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -5,32 +5,39 @@ var $ = jQuery;
 // here, the index maps to the error code returned from getValidationError
 var wcPvPhoneErrorMap = wcPvJson.validationErrors;
 // start
-if ($( '.wc-pv-intl input' ).length == 0) {// add class, some checkout plugin has overriden my baby
-    $( '#billing_phone_field' ).addClass( 'wc-pv-phone wc-pv-intl' );
-}
+$( document.body ).bind( 'updated_checkout', function( data ) {
+    if ($( '.wc-pv-intl input' ).length == 0) {// add class, some checkout plugin has overriden my baby
+        $( '#billing_phone_field' ).addClass( 'wc-pv-phone wc-pv-intl' );
+    }
+    initWcPvPhoneIntl();
+});
+
 // Set default country.
 var wcPvDefCountry = ( wcPvJson.defaultCountry == '' ? $( `${wcPvJson.parentPage} #billing_country` ).val() : wcPvJson.defaultCountry );
 
 let separateDialCode = ( wcPvJson.separateDialCode == 1 ? true : false );
 let onlyCountries    = wcPvJson.onlyCountries.map( value => { return value.toUpperCase(); } );
 
-var wcPvPhoneIntl = $( '.wc-pv-intl input' ).intlTelInput(
-    {
-        initialCountry: ( ( wcPvDefCountry == '' || wcPvDefCountry == undefined ) ? 'NG' : wcPvDefCountry ),
-        onlyCountries: onlyCountries,
-        separateDialCode: separateDialCode,
-        utilsScript: wcPvJson.utilsScript,
-        preferredCountry: '',
-        //autoHideDialCode: true,
-        //nationalMode: false,
-        /* geoIpLookup: function(callback) {
-		$.get('https://ipinfo.io', function() {}, "jsonp").always(function(resp) {
-		const countryCode = (resp && resp.country) ? resp.country : '';//asking for payment shaa,smh
-		callback(countryCode);
-		});
-		},//to pick user country */
-    }
-);
+function initWcPvPhoneIntl() {
+    return $( '.wc-pv-intl input' ).intlTelInput(
+        {
+            initialCountry: ( ( wcPvDefCountry == '' || wcPvDefCountry == undefined ) ? 'NG' : wcPvDefCountry ),
+            onlyCountries: onlyCountries,
+            separateDialCode: separateDialCode,
+            utilsScript: wcPvJson.utilsScript,
+            preferredCountry: '',
+            //autoHideDialCode: true,
+            //nationalMode: false,
+            /* geoIpLookup: function(callback) {
+            $.get('https://ipinfo.io', function() {}, "jsonp").always(function(resp) {
+            const countryCode = (resp && resp.country) ? resp.country : '';//asking for payment shaa,smh
+            callback(countryCode);
+            });
+            },//to pick user country */
+        }
+    );
+}
+var wcPvPhoneIntl = initWcPvPhoneIntl();
 
 /*if (wcPvJson.userPhone !== undefined ) {
 	wcPvPhoneIntl.intlTelInput("setNumber").val(wcPvJson.userPhone);


### PR DESCRIPTION
The [`woocommerce_update_order_review_fragments`](https://github.com/woocommerce/woocommerce/blob/c15488d8402d149a1a6551d73057d31a0730bddb/includes/class-wc-ajax.php#L385-L391) filter in `WC_AJAX::update_order_review()` allows developers to rewrite the billing fields of a checkout. When this happens, woocommerce-phone-validator must re-initialize against the form.

This change binds initialization to WooCommerce [frontend/checkout.js's `updated_checkout` trigger](https://github.com/woocommerce/woocommerce/blob/e711a447feaf3d6020204e4319fdd5ba47c3f0b9/assets/js/frontend/checkout.js#L418).

I'm not particularly advanced with JavaScript. Maybe `var wcPvPhoneIntl = initWcPvPhoneIntl();` should be inside the `bind` and just `var wcPvPhoneIntl;` outside. 