### PR TITLE
Bugfix: geolocate default country

### DIFF
--- a/includes/class-wc-pv.php
+++ b/includes/class-wc-pv.php
@@ -239,6 +239,12 @@ final class WC_PV {
 				$default                 = $country;
 			}
 		}
+		if( empty( $default ) ) {
+			$geo = WC_Geolocation::geolocate_ip();
+			if ( !empty( $geo['country'] ) ) {
+				$default = $geo['country'];
+			}
+		}
 		return apply_filters( 'wc_pv_set_default_country', $default );
 	}
 


### PR DESCRIPTION
When the WooCommerce setting "Default customer location" is set to "No location by default", and the customer is not logged in, it results in a JavaScript error: "Uncaught Error: No country data for 'default'
| intlTelInput-jquery.min.js:7:20325". Even after selecting a country at checkout, woocommerce-phone-validator still fails to work.

This change attempts to always provide a country, although it is not perfectly adhering to "no country by default".